### PR TITLE
Add "Bench of the Final Judge"

### DIFF
--- a/src/static/itemInheritance.js
+++ b/src/static/itemInheritance.js
@@ -24,6 +24,7 @@ export default {
   68361: [{id: 68362, count: 1}], // Magnanimous Choir Bell
   67374: [{id: 47909, count: 3}], // Hexed Outfit
   86093: [{id: 68063, count: 1}, {id: 19721, count: 1}], // Funerary Incense
+  86153: [{id: 85653, count: 1}], // Bench of the Final Judge
 
   // Ectoplasm gambling containers
   69981: [{id: 19721, count: 50}], // Massive Glob of Ectoplasm (exotic)


### PR DESCRIPTION
Added an entry to itemInheritance.js so that [Bench of the Final Judge (86153)](https://api.guildwars2.com/v2/items?ids=86153&lang=en) inherits from [Shrouded Bench of the Final Judge (85653)](https://api.guildwars2.com/v2/items?ids=85653&lang=en).

Addresses issue [#974](https://github.com/gw2efficiency/issues/issues/974).